### PR TITLE
Support older versions of Symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^7.1",
         "behat/behat": "^3.3",
         "psr/container": "^1.0",
-        "symfony/dependency-injection": "^3.3"
+        "symfony/dependency-injection": "^2.7 || ^3.0"
     },
     "require-dev": {
         "zendframework/zend-servicemanager": "^3.3"

--- a/src/services.yml
+++ b/src/services.yml
@@ -2,6 +2,8 @@ services:
   psr_container:
     class: RoaveBehatPsrContainer
     factory: ['Roave\BehatPsrContainer\ContainerFactory', 'createContainerFromIncludedFile']
-    tags: ['helper_container.container']
+    tags:
+      - {'name': 'helper_container.container'}
     shared: false
+    scope: prototype
     arguments: ["%roave.behat.psr.container.included.file%"]


### PR DESCRIPTION
In older versions of Symfony service container:
* The short `tag` syntax is not supported
* Scope is defined differently

This adds backward compatibility to the oldest currently supported versions