### PR TITLE
Configurable container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ default:
           - "@Whatever\\Service\\Name"
 ```
 
+If for some reason you want to use a name other than `psr_container` for the container (e.g. collision with another extension) this can 
+be overridden:
+
+```yaml
+  extensions:
+    Roave\BehatPsrContainer\PsrContainerExtension:
+      container: 'config/container.php'
+      name: 'my_container'
+```
+
 Just for clarity (and hopefully ease of understanding), this would be the equivalent of doing this in plain PHP:
 
 ```php

--- a/behat.yml
+++ b/behat.yml
@@ -1,11 +1,12 @@
 default:
   suites:
     my_suite:
-      services: "@psr_container"
+      services: "@my_container"
       contexts:
         - RoaveTest\BehatPsrContainer\FeatureContext:
           - "@RoaveTest\\BehatPsrContainer\\TestService"
 
   extensions:
     Roave\BehatPsrContainer\PsrContainerExtension:
-      container: 'features/bootstrap/example-zend-servicemanager-container.php'
+      container: "features/bootstrap/example-zend-servicemanager-container.php"
+      name: "my_container"

--- a/src/PsrContainerExtension.php
+++ b/src/PsrContainerExtension.php
@@ -44,7 +44,15 @@ final class PsrContainerExtension implements Extension
         $definition = new Definition(ContainerInterface::class, ["%roave.behat.psr.container.included.file%"]);
         $definition->setFactory([ContainerFactory::class, 'createContainerFromIncludedFile']);
         $definition->addTag('helper_container.container');
-        $definition->setShared(false);
+
+        if (method_exists($definition, 'setShared')) {
+            // introduced in Symfony 2.8
+            $definition->setShared(false);
+        }
+        else {
+            // removed in Symfony 3.0
+            $definition->setScope(ContainerBuilder::SCOPE_PROTOTYPE);
+        }
 
         $container->setDefinition($config['name'], $definition);
     }

--- a/src/PsrContainerExtension.php
+++ b/src/PsrContainerExtension.php
@@ -32,6 +32,7 @@ final class PsrContainerExtension implements Extension
         $builder
             ->children()
                 ->scalarNode('container')->defaultValue('config/container.php')->end()
+                ->scalarNode('name')->defaultValue('psr_container')->end()
             ->end()
         ->end();
     }
@@ -45,6 +46,6 @@ final class PsrContainerExtension implements Extension
         $definition->addTag('helper_container.container');
         $definition->setShared(false);
 
-        $container->setDefinition('psr_container', $definition);
+        $container->setDefinition($config['name'], $definition);
     }
 }

--- a/src/PsrContainerExtension.php
+++ b/src/PsrContainerExtension.php
@@ -40,20 +40,31 @@ final class PsrContainerExtension implements Extension
     public function load(ContainerBuilder $container, array $config)
     {
         $container->setParameter('roave.behat.psr.container.included.file', $config['container']);
+        $container->setDefinition($config['name'], $this->createContainerDefinition());
+    }
 
+    private function createContainerDefinition() : Definition
+    {
         $definition = new Definition(ContainerInterface::class, ["%roave.behat.psr.container.included.file%"]);
         $definition->setFactory([ContainerFactory::class, 'createContainerFromIncludedFile']);
         $definition->addTag('helper_container.container');
 
+        $this->setContainerScope($definition);
+
+        return $definition;
+    }
+
+    /**
+     * The way to set service scope was improved across Symfony versions:
+     *  - setShared was introduced in 2.8
+     *  - setScope (and the constant) were removed in 3.0
+     */
+    private function setContainerScope($definition) : void
+    {
         if (method_exists($definition, 'setShared')) {
-            // introduced in Symfony 2.8
             $definition->setShared(false);
-        }
-        else {
-            // removed in Symfony 3.0
+        } else {
             $definition->setScope(ContainerBuilder::SCOPE_PROTOTYPE);
         }
-
-        $container->setDefinition($config['name'], $definition);
     }
 }

--- a/src/PsrContainerExtension.php
+++ b/src/PsrContainerExtension.php
@@ -5,9 +5,11 @@ namespace Roave\BehatPsrContainer;
 
 use Behat\Testwork\ServiceContainer\Extension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 final class PsrContainerExtension implements Extension
@@ -38,7 +40,11 @@ final class PsrContainerExtension implements Extension
     {
         $container->setParameter('roave.behat.psr.container.included.file', $config['container']);
 
-        $loader = new YamlFileLoader($container, new FileLocator(__DIR__));
-        $loader->load('services.yml');
+        $definition = new Definition(ContainerInterface::class, ["%roave.behat.psr.container.included.file%"]);
+        $definition->setFactory([ContainerFactory::class, 'createContainerFromIncludedFile']);
+        $definition->addTag('helper_container.container');
+        $definition->setShared(false);
+
+        $container->setDefinition('psr_container', $definition);
     }
 }

--- a/src/services.yml
+++ b/src/services.yml
@@ -1,9 +1,0 @@
-services:
-  psr_container:
-    class: RoaveBehatPsrContainer
-    factory: ['Roave\BehatPsrContainer\ContainerFactory', 'createContainerFromIncludedFile']
-    tags:
-      - {'name': 'helper_container.container'}
-    shared: false
-    scope: prototype
-    arguments: ["%roave.behat.psr.container.included.file%"]


### PR DESCRIPTION
Rather than using the magic string `psr_container` users may want to name the container (especially if other extensions are defining their own containers). This adds a config option.

To do this simply, the service configuration has been moved out of Yaml into PHP.