### PR TITLE
Update PHP requirement and CI setup to test against PHP 8.2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -49,6 +49,7 @@ jobs:
         php-version:
           - "8.0"
           - "8.1"
+          - "8.2"
         operating-system:
           - "ubuntu-latest"
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PSR-11 Container extension for Behat",
     "type": "library",
     "require": {
-        "php": "~8.0.0 || ~8.1.0",
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "behat/behat": "^3.11.0",
         "psr/container": "^1.1.2",
         "symfony/dependency-injection": "^6.0.13"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea249f3135ffcf98fa32c6f9e7902ca4",
+    "content-hash": "2f8bfa9f2b241897de140e9a60751c41",
     "packages": [
         {
             "name": "behat/behat",
@@ -3868,7 +3868,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.0.0 || ~8.1.0"
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
- The PR @renovate did allowing php 8.2 requirement
  - https://github.com/Roave/behat-psr11extension/pull/29
- CI setup to run php tests under 8.2 version
